### PR TITLE
The links do not be shown when blogs are in nested ns -- close #6

### DIFF
--- a/action.php
+++ b/action.php
@@ -66,6 +66,9 @@ class action_plugin_bloglinks extends DokuWiki_Action_Plugin {
             return;
 
         $namespace = $this->_getActiveNamespace();
+        if(! $namespace){
+            $namespace = getNS(getID());
+        }
         if ($namespace)
             $this->_printLinks($this->_getRelatedEntries($namespace));
 


### PR DESCRIPTION
To fix the issue, getting namespace explicitly in handle_act_render. close #6